### PR TITLE
BIDS-compatible unit update

### DIFF
--- a/java/tagging/ctagger/src/edu/utsa/tagger/HedXmlModel.java
+++ b/java/tagging/ctagger/src/edu/utsa/tagger/HedXmlModel.java
@@ -25,11 +25,14 @@ public class HedXmlModel {
 	private Set<TagXmlModel> node;
 	@XmlElement
 	private UnitClassesXmlModel unitClasses;
+	@XmlElement
+	private UnitModifiersXmlModel unitModifiers;
 
 	public HedXmlModel() {
 		version = new String();
 		node = new LinkedHashSet<TagXmlModel>();
 		unitClasses = new UnitClassesXmlModel();
+		unitModifiers = new UnitModifiersXmlModel();
 	}
 
 	public Set<TagXmlModel> getTags() {
@@ -43,6 +46,8 @@ public class HedXmlModel {
 	public UnitClassesXmlModel getUnitClasses() {
 		return unitClasses;
 	}
+
+	public UnitModifiersXmlModel getUnitModifiers() {return unitModifiers;}
 
 	public void setTags(Set<TagXmlModel> tags) {
 		this.node = tags;

--- a/java/tagging/ctagger/src/edu/utsa/tagger/Tagger.java
+++ b/java/tagging/ctagger/src/edu/utsa/tagger/Tagger.java
@@ -26,6 +26,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.lang.reflect.Array;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
@@ -59,7 +60,8 @@ public class Tagger {
     private final String[] tsvHeader = new String[]{"Event code", "Event category", "Event label", "Event long name", "Event description", "Other tags"};
     private TaggerSet<AbstractTagModel> uniqueTags = new TaggerSet();
     public HashMap<String, String> unitClassDefaults = new HashMap();
-    public HashMap<String, String> unitClasses = new HashMap();
+    public HashMap<String, List<UnitXmlModel>> unitClasses = new HashMap();
+    public HashMap<String, ArrayList<String>> unitModifiers = new HashMap();
     private String hedVersion = "";
 
     public static String[] concat(String[] s1, String[] s2) {
@@ -164,22 +166,22 @@ public class Tagger {
         return this.eventList.add(event);
     }
 
-    public boolean addGroupBase(TaggedEvent taggedEvent, Integer groupId, TaggerSet<AbstractTagModel> tags) {
-        if (!taggedEvent.addGroup(groupId)) {
-            return false;
-        } else {
-            Iterator var5 = tags.iterator();
+//    public boolean addGroupBase(TaggedEvent taggedEvent, Integer groupId, TaggerSet<AbstractTagModel> tags) {
+//        if (!taggedEvent.addGroup(groupId)) {
+//            return false;
+//        } else {
+//            Iterator var5 = tags.iterator();
+//
+//            while(var5.hasNext()) {
+//                AbstractTagModel tag = (AbstractTagModel)var5.next();
+//                taggedEvent.addTagToGroup(groupId, tag);
+//            }
+//
+//            return true;
+//        }
+//    }
 
-            while(var5.hasNext()) {
-                AbstractTagModel tag = (AbstractTagModel)var5.next();
-                taggedEvent.addTagToGroup(groupId, tag);
-            }
-
-            return true;
-        }
-    }
-
-    public boolean addNestedGroupWithTags(TaggedEvent taggedEvent, Integer parentGroupId, Integer groupId, TaggerSet<AbstractTagModel> tags) {
+    public boolean addGroupBase(TaggedEvent taggedEvent, Integer parentGroupId, Integer groupId, TaggerSet<AbstractTagModel> tags) {
         if (!taggedEvent.addGroup(parentGroupId,groupId)) {
             return false;
         } else {
@@ -239,12 +241,14 @@ public class Tagger {
         TaggerSet<TaggedEvent> selectedEvents = new TaggerSet(); // list of selected TaggedEvent. TaggedEvent equivalent of eventIds
         TaggerSet<AbstractTagModel> tags = new TaggerSet();
         boolean eventSelected = false;
+        TreeMap<Integer, Integer> parentChildrenMap = new TreeMap<>(); // map that keeps track of which groupId add to which parent groupId
         for (TaggedEvent event : eventList) {
             for (int id : selectedIds) {
                 if (event.containsGroup(id)) {
                     selectedEvents.add(event);
                     ++groupIdCounter;
                     event.addGroup(id, groupIdCounter);
+                    parentChildrenMap.put(id, groupIdCounter);
                     newEventGroupIds.add(groupIdCounter);
                     eventSelected = true;
                 }
@@ -256,6 +260,7 @@ public class Tagger {
             historyItem.type = Type.GROUPS_ADDED;
             historyItem.events = selectedEvents;
             historyItem.groupIds = newEventGroupIds;
+            historyItem.parentChildrenGroupIds = parentChildrenMap;
             historyItem.tags = tags;
             this.history.add(historyItem);
         }
@@ -662,7 +667,27 @@ public class Tagger {
             this.unitClasses.put(unitClassXmlModel.getName(), unitClassXmlModel.getUnits());
             this.unitClassDefaults.put(unitClassXmlModel.getName(), unitClassXmlModel.getDefault());
         }
+    }
 
+    /**
+     * generate a hashmap of unit modifiers.
+     * @param unitModifiersXmlModel HashMap of unit modifiers. Contains 2 key-value paris:
+     *                                  symbolModifier key is associated with list of unit modifiers for SI unit SYMBOL
+     *                                  unitModifier key is associated with list of unit modifiers for full-letter SI units
+     */
+    private void createUnitModifierHashMapFromXml(UnitModifiersXmlModel unitModifiersXmlModel) {
+        unitModifiers.put("symbol", new ArrayList<String>());
+        unitModifiers.put("unit", new ArrayList<String>());
+        for (UnitModifierXmlModel mod : unitModifiersXmlModel.getUnitModifiers()) {
+            if (mod.isSIUnitSymbolModifier()) {
+                ArrayList<String> units = (ArrayList<String>)unitModifiers.get("symbol");
+                units.add(mod.getName());
+            }
+            else {
+                ArrayList<String> units = (ArrayList<String>) unitModifiers.get("unit");
+                units.add(mod.getName());
+            }
+        }
     }
 
     public void deleteTag(AbstractTagModel tag) {
@@ -1811,6 +1836,7 @@ public class Tagger {
         }
 
         this.createUnitClassHashMapFromXml(hedXmlModel.getUnitClasses());
+        this.createUnitModifierHashMapFromXml(hedXmlModel.getUnitModifiers());
         this.createTagSets(hedXmlModel.getTags());
     }
 
@@ -2366,7 +2392,7 @@ public class Tagger {
             String key = (String)unitClassKeys.next();
             UnitClassXmlModel unitClassXml = new UnitClassXmlModel();
             unitClassXml.setName(key);
-            unitClassXml.setUnits((String)this.unitClasses.get(key));
+            unitClassXml.setUnits((UnitsXmlModel) this.unitClasses.get(key));
             unitClassXml.setDefault((String)this.unitClassDefaults.get(key));
             unitClassesXml.addUnitClass(unitClassXml);
         }

--- a/java/tagging/ctagger/src/edu/utsa/tagger/UnitClassXmlModel.java
+++ b/java/tagging/ctagger/src/edu/utsa/tagger/UnitClassXmlModel.java
@@ -1,12 +1,10 @@
 package edu.utsa.tagger;
 
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.*;
 
 /**
  * This class is an XML model corresponding to a tag in the HED hierarchy.
@@ -17,16 +15,15 @@ import javax.xml.bind.annotation.XmlType;
 @XmlType(name = "unitClass")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class UnitClassXmlModel {
-	@XmlAttribute(name = "default")
+	@XmlAttribute(name = "defaultUnits")
 	private String defaultUnit = "";
-	private String name = "";
-	private String units = "";
-	private Set<UnitClassXmlModel> unitClass = new LinkedHashSet<UnitClassXmlModel>();
+	private String name = ""; // name of the unit class, e.g. Time, PhysicalLength...
+	private UnitsXmlModel units;
 
-	public void addChild(UnitClassXmlModel child) {
-		unitClass.add(child);
-	}
-
+//	public void addChild(UnitClassXmlModel child) {
+//		unitClass.add(child);
+//	}
+//
 	public String getDefault() {
 		return defaultUnit;
 	}
@@ -43,12 +40,11 @@ public class UnitClassXmlModel {
 		this.name = name;
 	}
 
-	public String getUnits() {
-		return units;
+	public List<UnitXmlModel> getUnits() {
+		return units.getUnits();
 	}
 
-	public void setUnits(String units) {
+	public void setUnits(UnitsXmlModel units) {
 		this.units = units;
 	}
-
 }

--- a/java/tagging/ctagger/src/edu/utsa/tagger/UnitModifierXmlModel.java
+++ b/java/tagging/ctagger/src/edu/utsa/tagger/UnitModifierXmlModel.java
@@ -1,0 +1,38 @@
+package edu.utsa.tagger;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * This class is an XML model corresponding to a tag in the HED hierarchy.
+ * 
+ * @author Lauren Jett, Rebecca Strautman, Thomas Rognon, Jeremy Cockfield, Kay
+ *         Robbins
+ */
+@XmlType(name = "unitModifier")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class UnitModifierXmlModel {
+    @XmlAttribute(name = "SIUnitModifier")
+	private boolean sIUnitModifier = false;
+	@XmlAttribute(name = "SIUnitSymbolModifier")
+	private boolean sIUnitSymbolModifier = false;
+	private String name = ""; // name of the unit modifier
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+	public boolean isSIUnitModifier() {
+		return sIUnitModifier;
+	}
+	public boolean isSIUnitSymbolModifier() {
+		return sIUnitSymbolModifier;
+	}
+}

--- a/java/tagging/ctagger/src/edu/utsa/tagger/UnitModifiersXmlModel.java
+++ b/java/tagging/ctagger/src/edu/utsa/tagger/UnitModifiersXmlModel.java
@@ -1,0 +1,30 @@
+package edu.utsa.tagger;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * This class is an XML model corresponding to a tag in the HED hierarchy.
+ * 
+ * @author Lauren Jett, Rebecca Strautman, Thomas Rognon, Jeremy Cockfield, Kay
+ *         Robbins
+ */
+@XmlType(propOrder = {}, name = "unitModifiers")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class UnitModifiersXmlModel {
+
+	private ArrayList<UnitModifierXmlModel> unitModifier = new ArrayList<UnitModifierXmlModel>();
+
+	public void setUnitModifiers(ArrayList<UnitModifierXmlModel> unitModifier) {
+		this.unitModifier = unitModifier;
+	}
+
+	public ArrayList<UnitModifierXmlModel> getUnitModifiers() {
+		return unitModifier;
+	}
+
+}

--- a/java/tagging/ctagger/src/edu/utsa/tagger/UnitXmlModel.java
+++ b/java/tagging/ctagger/src/edu/utsa/tagger/UnitXmlModel.java
@@ -1,0 +1,42 @@
+package edu.utsa.tagger;
+
+import javax.xml.bind.annotation.*;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * This class is an XML model corresponding to a tag in the HED hierarchy.
+ * 
+ * @author Lauren Jett, Rebecca Strautman, Thomas Rognon, Jeremy Cockfield, Kay
+ *         Robbins
+ */
+@XmlType(propOrder = {}, name = "unit")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class UnitXmlModel {
+    @XmlAttribute(name="SIUnit")
+	private boolean sIUnit = false;
+    @XmlAttribute
+	private boolean unitSymbol = false;
+    @XmlValue
+	private String name; // name of the unit class, e.g. Time, PhysicalLength...
+
+    public UnitXmlModel() {
+
+	}
+	public boolean isSIUnit() {
+		return sIUnit;
+	}
+	public boolean isUnitSymbol() {
+		return unitSymbol;
+	}
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+	public void setsIUnit(boolean si) {this.sIUnit = si;}
+	public void setUnitSymbol(boolean unitSymbol) {this.unitSymbol = unitSymbol;}
+
+}

--- a/java/tagging/ctagger/src/edu/utsa/tagger/UnitsXmlModel.java
+++ b/java/tagging/ctagger/src/edu/utsa/tagger/UnitsXmlModel.java
@@ -1,0 +1,29 @@
+package edu.utsa.tagger;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * This class is an XML model corresponding to a tag in the HED hierarchy.
+ * 
+ * @author Lauren Jett, Rebecca Strautman, Thomas Rognon, Jeremy Cockfield, Kay
+ *         Robbins
+ */
+@XmlType(propOrder = {}, name = "units")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class UnitsXmlModel {
+
+	private List<UnitXmlModel> unit;
+
+	public void setUnits(List<UnitXmlModel> units) {
+		this.unit = units;
+	}
+
+	public List<UnitXmlModel> getUnits() {
+		return unit;
+	}
+}

--- a/java/tagging/ctagger/src/edu/utsa/tagger/gui/AddValueView.java
+++ b/java/tagging/ctagger/src/edu/utsa/tagger/gui/AddValueView.java
@@ -14,9 +14,7 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.font.TextAttribute;
 import java.awt.geom.Rectangle2D;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.JComboBox;
@@ -30,6 +28,7 @@ import javax.swing.event.DocumentListener;
 
 import edu.utsa.tagger.AbstractTagModel;
 import edu.utsa.tagger.Tagger;
+import edu.utsa.tagger.UnitXmlModel;
 import edu.utsa.tagger.guisupport.*;
 import org.junit.Test;
 
@@ -180,12 +179,19 @@ public class AddValueView extends ConstraintContainer {
 		String[] unitsArray = {};
 		for (int i = 0; i < unitClassArray.length; i++) {
 			if (tagger.unitClasses.get(unitClassArray[i]) != null) {
-				String[] units = Tagger.trimStringArray(tagger.unitClasses.get(
-						unitClassArray[i]).split(","));
-				unitsArray = Tagger.concat(unitsArray, units);
+				List<UnitXmlModel> units = tagger.unitClasses.get(unitClassArray[i]);
+				String[] unitStrings = new String[units.size()];
+				int j = 0;
+				for (UnitXmlModel unit : units) {
+					unitStrings[j++] = unit.getName();
+				}
+				unitsArray = Tagger.concat(unitsArray, unitStrings);
+//				String[] units = Tagger.trimStringArray(tagger.unitClasses.get(
+//						unitClassArray[i]).split(","));
+//				unitsArray = Tagger.concat(unitsArray, units);
 			}
 		}
-		Arrays.sort(unitsArray);
+//		Arrays.sort(unitsArray);
 		units.setModel(new DefaultComboBoxModel(unitsArray));
 		setDefaultUnit();
 	}
@@ -375,7 +381,7 @@ public class AddValueView extends ConstraintContainer {
 	}
 
 	private void handleCancel() {
-        this.tagModel.setInAddValue(false);
+//        this.tagModel.setInAddValue(false);
         if (this.tagger.isHEDVersionTag(this.tagModel)) {
             this.appView.updateTagsPanel();
             this.appView.scrollToPreviousTag();
@@ -403,7 +409,7 @@ public class AddValueView extends ConstraintContainer {
 		}
 
 		AbstractTagModel transientTag = this.tagger.createTransientTagModel(this.tagModel, valueStr);
-		this.tagModel.setInAddValue(false);
+//		this.tagModel.setInAddValue(false);
 		if (this.tagger.isHEDVersionTag(this.tagModel)) {
 			this.handleHEDTag(transientTag);
 			return;

--- a/java/tagging/ctagger/src/edu/utsa/tagger/gui/GuiTagModel.java
+++ b/java/tagging/ctagger/src/edu/utsa/tagger/gui/GuiTagModel.java
@@ -144,6 +144,10 @@ public class GuiTagModel extends AbstractTagModel {
 		return tagView;
 	}
 
+	public TaggerView getAppView() {return appView;}
+
+	public Tagger getTagger() {return tagger;}
+
 	public ArrayList<AbstractTagModel> getAttributes() {
 		return attributes;
 	}

--- a/java/tagging/ctagger/src/edu/utsa/tagger/gui/TagEnterSearchView.java
+++ b/java/tagging/ctagger/src/edu/utsa/tagger/gui/TagEnterSearchView.java
@@ -23,7 +23,7 @@ public class TagEnterSearchView extends TagSearchView {
     public void mouseClickedEvent(Tagger tagger, TaggerView appView) {
         if (getModel().takesValue()){
             TagValueInputDialog dialog = new TagValueInputDialog(eventEnterTagView, this);
-            dialog.setVisible(true);
+//            dialog.setVisible(true);
         }
         else
             addTagToEvent();

--- a/java/tagging/ctagger/src/edu/utsa/tagger/gui/TaggerView.java
+++ b/java/tagging/ctagger/src/edu/utsa/tagger/gui/TaggerView.java
@@ -649,6 +649,9 @@ public class TaggerView extends ConstraintContainer {
         this.searchResultsScrollPane.setVisible(false);
         this.tagsPanel.removeAll();
         String lastVisibleTagPath = null;
+        /* addValueTag contains tag that is in addValueView in the TagsPanel
+           this implementation is to merge the legacy AddValueView with TagValueInputDialog */
+        GuiTagModel addValueTag = null;
 
         Iterator var3 = this.tagger.getTagSet().iterator();
         while (true) {
@@ -659,6 +662,11 @@ public class TaggerView extends ConstraintContainer {
                     this.autoCollapse = false;
                     this.schemaFrame.getContentPane().validate();
                     this.schemaFrame.getContentPane().repaint();
+                    /* When end of add tag (GUI update finished), show TagValueInputDialog
+                       to allow tag value entry */
+                    if (addValueTag != null) {
+                        new TagValueInputDialog(addValueTag);
+                    }
 //                    validate();
 //                    repaint();
                     return;
@@ -682,9 +690,11 @@ public class TaggerView extends ConstraintContainer {
             }
 
             if (guiTagModel.isInAddValue()) {
-                this.tagsPanel.add(guiTagModel.getAddValueView());
+                addValueTag = guiTagModel;
+//                this.tagsPanel.add(guiTagModel.getAddValueView());  // legacy AddValueView implementation (add a new view to the TagPanel for value input)
             }
         }
+
     }
 
     public void updateEventsPanel() {


### PR DESCRIPTION
* Update XML unmarshaller to accommodate new <UnitClasses> structure and <UnitModifiers>
* Update unitClasses data structure to store UnitXmlModel class instead of just comma-separated unit string
* Add unitModifier data structure
* Replace (functionally) AddValueView by TagValueInputDialog. AddValueView still exists but unused in practice
* Update TagValueInputDialog to allow submodifier specification based on selected unit